### PR TITLE
Make blamer process asynchronous

### DIFF
--- a/VSGitBlame.Core/CommitInfo.cs
+++ b/VSGitBlame.Core/CommitInfo.cs
@@ -4,6 +4,10 @@ namespace VSGitBlame.Core;
 
 public class CommitInfo
 {
+    public static readonly CommitInfo InProgress = new CommitInfo() { ShowDetails = false, Summary = "Blame in progress.." };
+    public static readonly CommitInfo Uncommitted = new CommitInfo() { ShowDetails = false, Summary = "Uncommitted changes"};
+
+    public bool ShowDetails { get; set; } = true;
     public string Hash { get; set; } = string.Empty;
     public string AuthorName { get; set; } = string.Empty;
     public string AuthorEmail { get; set; } = string.Empty;

--- a/VSGitBlame/CommitInfoViewFactory.cs
+++ b/VSGitBlame/CommitInfoViewFactory.cs
@@ -22,6 +22,7 @@ public static class CommitInfoViewFactory
 
     static bool _firstMouseMoveFired = false;
     static bool _isDetailsVisible = false;
+    static bool _showDetails = false;
     static IAdornmentLayer _adornmentLayer;
     
     private static VSGitBlamePackage _package;
@@ -153,7 +154,7 @@ public static class CommitInfoViewFactory
                 return;
             }
 
-            if (_isDetailsVisible)
+            if (_isDetailsVisible || _showDetails == false)
                 return;
 
             _detailsViewContainer.Visibility = Visibility.Visible;
@@ -190,14 +191,26 @@ public static class CommitInfoViewFactory
             _adornmentLayer = adornmentLayer;
         }
 
-        _summaryView.Text = $"{commitInfo.AuthorName}, {commitInfo.Time:yyyy/MM/dd HH:mm} • {commitInfo.Summary}";
-        _profileIcon.Source = new BitmapImage(new Uri(GetGravatarUrl(commitInfo.AuthorEmail), UriKind.Absolute));
-        _commitDetailsView.Text =
-            $"""
+        if (commitInfo.ShowDetails == false)
+        {
+            _summaryView.Text = commitInfo.Summary;
+            _profileIcon.Source = null;
+            _commitDetailsView.Text = string.Empty;
+            _detailsViewContainer.Visibility = Visibility.Hidden;
+        }
+        else
+        {
+            _summaryView.Text = $"{commitInfo.AuthorName}, {commitInfo.Time:yyyy/MM/dd HH:mm} • {commitInfo.Summary}";
+            _profileIcon.Source = new BitmapImage(new Uri(GetGravatarUrl(commitInfo.AuthorEmail), UriKind.Absolute));
+            _commitDetailsView.Text =
+                $"""
             {commitInfo.AuthorName} | {commitInfo.Time:f}
             {commitInfo.Summary}
             Commit: {commitInfo.Hash.Substring(7)}
             """;
+        }
+
+        _showDetails = commitInfo.ShowDetails;
         _container.Visibility = Visibility.Visible;
 
         return _container;


### PR DESCRIPTION
Make blamer process asynchronous so VS doesn't lag on large files/deep history/slow disk waiting for git output, add detail presets for in-progress blame and uncommitted changes

Shows `Blame in progress..` while the blamer is running, shows `Uncommitted changes` for (self explanatory) instead of the `0000000` hash with an excess of useless information. Doesn't show details on-hover for these two cases.

Also makes quick summary more reliable i.e. showing up on launch, the first time a file is opened, when a view is moved into/out of a split pane or separate window, etc