### PR TITLE
Make adornments per-view so split panes/windows can all show blame simultaneously

### DIFF
--- a/VSGitBlame/CommitInfoViewFactory.cs
+++ b/VSGitBlame/CommitInfoViewFactory.cs
@@ -8,24 +8,31 @@ using VSGitBlame.Core;
 using System.Linq;
 using Microsoft.VisualStudio.Text.Editor;
 using Color = System.Drawing.Color;
+using System.Collections.Generic;
 
 namespace VSGitBlame;
 
-public static class CommitInfoViewFactory
+public class CommitInfoView
 {
-    static Border _container;
-    static TextBlock _summaryView;
-    static TextBlock _commitDetailsView;
-    static Image _profileIcon;
-    static StackPanel _detailsView;
-    static Border _detailsViewContainer;
+    public Border _container;
+    public TextBlock _summaryView;
+    public TextBlock _commitDetailsView;
+    public Image _profileIcon;
+    public StackPanel _detailsView;
+    public Border _detailsViewContainer;
 
-    static bool _firstMouseMoveFired = false;
-    static bool _isDetailsVisible = false;
-    static IAdornmentLayer _adornmentLayer;
-    
+    public bool _firstMouseMoveFired;
+    public bool _isDetailsVisible;
+
+    public IAdornmentLayer _adornmentLayer;
+}
+
+public static class CommitInfoViewFactory
+{    
     private static VSGitBlamePackage _package;
     private static CommitInfoViewOptions _options;
+
+    private static Dictionary<IAdornmentLayer, CommitInfoView> _commitInfoViews = new();
 
     public static void InitializeSettings(VSGitBlamePackage package)
     {
@@ -52,155 +59,155 @@ public static class CommitInfoViewFactory
 
     private static void ApplySettings()
     {
-        if (_summaryView != null && _options != null)
+        foreach (CommitInfoView view in _commitInfoViews.Values)
         {
-            // Apply summary view settings
-            _summaryView.FontSize = _options.SummaryFontSize;
-
-            // Override the foreground color if specified, otherwise use theme detection
-            if (_options.SummaryFontColor != Color.Transparent)
+            if (view._summaryView != null && _options != null)
             {
-                _summaryView.Foreground = new SolidColorBrush(System.Windows.Media.Color.FromArgb(
-                    _options.SummaryFontColor.A, 
-                    _options.SummaryFontColor.R, 
-                    _options.SummaryFontColor.G, 
-                    _options.SummaryFontColor.B));
+                // Apply summary view settings
+                view._summaryView.FontSize = _options.SummaryFontSize;
+
+                // Override the foreground color if specified, otherwise use theme detection
+                if (_options.SummaryFontColor != Color.Transparent)
+                {
+                    view._summaryView.Foreground = new SolidColorBrush(System.Windows.Media.Color.FromArgb(
+                        _options.SummaryFontColor.A,
+                        _options.SummaryFontColor.R,
+                        _options.SummaryFontColor.G,
+                        _options.SummaryFontColor.B));
+                }
+                else
+                {
+                    // Use theme detection if no specific color is set
+                    var backgroundColor = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBackgroundColorKey);
+                    view._summaryView.Foreground = backgroundColor.GetBrightness() > 0.5 ?
+                        Brushes.DarkBlue :
+                        Brushes.LightGray;
+                }
             }
-            else
+
+            if (view._commitDetailsView != null && _options != null)
             {
-                // Use theme detection if no specific color is set
-                var backgroundColor = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBackgroundColorKey);
-                _summaryView.Foreground = backgroundColor.GetBrightness() > 0.5 ? 
-                    Brushes.DarkBlue : 
-                    Brushes.LightGray;
+                // Apply details view settings
+                view._commitDetailsView.FontSize = _options.DetailsFontSize;
+                view._commitDetailsView.Foreground = _options.GetDetailsFontBrush();
             }
-        }
 
-        if (_commitDetailsView != null && _options != null)
-        {
-            // Apply details view settings
-            _commitDetailsView.FontSize = _options.DetailsFontSize;
-            _commitDetailsView.Foreground = _options.GetDetailsFontBrush();
-        }
-
-        if (_detailsView != null && _options != null)
-        {
-            // Apply background color setting
-            _detailsViewContainer.Background = _options.GetDetailsBackgroundBrush();
+            if (view._detailsView != null && _options != null)
+            {
+                // Apply background color setting
+                view._detailsViewContainer.Background = _options.GetDetailsBackgroundBrush();
+            }
         }
     }
 
     static CommitInfoViewFactory()
     {
-        #region Summary View
-        var backgroundColor = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBackgroundColorKey);
-        _summaryView = new TextBlock
-        {
-            Opacity = 0.5,
-            Background = Brushes.Transparent,
-            Foreground = backgroundColor.GetBrightness() > 0.5 ? Brushes.DarkBlue : Brushes.LightGray,
-            FontStyle = FontStyles.Italic,
-            FontWeight = FontWeights.Normal,
-        };
-        #endregion
-
-        #region Details View
-        _detailsView = new StackPanel
-        {
-            Orientation = Orientation.Horizontal,
-        };
-
-        _profileIcon = new Image
-        {
-            Width = 50,
-            Height = 50,
-            Margin = new Thickness(0, 0, 3, 0),
-        };
-        _detailsView.Children.Add(_profileIcon);
-
-        _commitDetailsView = new TextBlock
-        {
-            Foreground = new SolidColorBrush(Colors.White),
-            FontWeight = FontWeights.Bold,
-        };
-        _detailsView.Children.Add(_commitDetailsView);
-
-        _detailsViewContainer = new Border
-        {
-            BorderThickness = new Thickness(1),
-            Background = new SolidColorBrush(Colors.DarkBlue),
-            BorderBrush = Brushes.Transparent,
-            Visibility = Visibility.Hidden,
-            Padding = new Thickness(5),
-        };
-        _detailsViewContainer.Child = _detailsView;
-        #endregion
-
-        #region Container
-        var rootPanel = new StackPanel
-        {
-            Orientation = Orientation.Vertical,
-            Background = Brushes.Transparent,
-        };
-        rootPanel.Children.Add(_summaryView);
-        rootPanel.Children.Add(_detailsViewContainer);
-
-        rootPanel.MouseMove += (sender, e) =>
-        {
-            if (!_firstMouseMoveFired)
-            {
-                _firstMouseMoveFired = true;
-                return;
-            }
-
-            if (_isDetailsVisible)
-                return;
-
-            _detailsViewContainer.Visibility = Visibility.Visible;
-            _isDetailsVisible = true;
-        };
-
-        rootPanel.MouseLeave += (sender, e) =>
-        {
-            _firstMouseMoveFired = false;
-            _isDetailsVisible = false;
-            _detailsViewContainer.Visibility = Visibility.Hidden;
-        };
-
-        _container = new Border
-        {
-            Margin = new Thickness(30, 0, 0, 0),
-        };
-        _container.Child = rootPanel;
-        #endregion
     }
 
     public static Border Get(CommitInfo commitInfo, IAdornmentLayer adornmentLayer)
     {
-        if (_adornmentLayer != null)
+        if (!_commitInfoViews.TryGetValue(adornmentLayer, out CommitInfoView view))
         {
-            if (_adornmentLayer != adornmentLayer)
+            view = new();
+            view._adornmentLayer = adornmentLayer;
+
+            #region Summary View
+            var backgroundColor = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBackgroundColorKey);
+            view._summaryView = new TextBlock
             {
-                _adornmentLayer.RemoveAllAdornments();
-                _adornmentLayer = adornmentLayer;
-            }
-        }
-        else
-        {
-            _adornmentLayer = adornmentLayer;
+                Opacity = 0.5,
+                Background = Brushes.Transparent,
+                Foreground = backgroundColor.GetBrightness() > 0.5 ? Brushes.DarkBlue : Brushes.LightGray,
+                FontStyle = FontStyles.Italic,
+                FontWeight = FontWeights.Normal,
+            };
+            #endregion
+
+            #region Details View
+            view._detailsView = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+            };
+
+            view._profileIcon = new Image
+            {
+                Width = 50,
+                Height = 50,
+                Margin = new Thickness(0, 0, 3, 0),
+            };
+            view._detailsView.Children.Add(view._profileIcon);
+
+            view._commitDetailsView = new TextBlock
+            {
+                Foreground = new SolidColorBrush(Colors.White),
+                FontWeight = FontWeights.Bold,
+            };
+            view._detailsView.Children.Add(view._commitDetailsView);
+
+            view._detailsViewContainer = new Border
+            {
+                BorderThickness = new Thickness(1),
+                Background = new SolidColorBrush(Colors.DarkBlue),
+                BorderBrush = Brushes.Transparent,
+                Visibility = Visibility.Hidden,
+                Padding = new Thickness(5),
+            };
+            view._detailsViewContainer.Child = view._detailsView;
+            #endregion
+
+            #region Container
+            var rootPanel = new StackPanel
+            {
+                Orientation = Orientation.Vertical,
+                Background = Brushes.Transparent,
+            };
+            rootPanel.Children.Add(view._summaryView);
+            rootPanel.Children.Add(view._detailsViewContainer);
+
+            rootPanel.MouseMove += (sender, e) =>
+            {
+                if (!view._firstMouseMoveFired)
+                {
+                    view._firstMouseMoveFired = true;
+                    return;
+                }
+
+                if (view._isDetailsVisible)
+                    return;
+
+                view._detailsViewContainer.Visibility = Visibility.Visible;
+                view._isDetailsVisible = true;
+            };
+
+            rootPanel.MouseLeave += (sender, e) =>
+            {
+                view._firstMouseMoveFired = false;
+                view._isDetailsVisible = false;
+                view._detailsViewContainer.Visibility = Visibility.Hidden;
+            };
+
+            view._container = new Border
+            {
+                Margin = new Thickness(30, 0, 0, 0),
+            };
+            view._container.Child = rootPanel;
+            #endregion
+
+            _commitInfoViews[adornmentLayer] = view;
         }
 
-        _summaryView.Text = $"{commitInfo.AuthorName}, {commitInfo.Time:yyyy/MM/dd HH:mm} • {commitInfo.Summary}";
-        _profileIcon.Source = new BitmapImage(new Uri(GetGravatarUrl(commitInfo.AuthorEmail), UriKind.Absolute));
-        _commitDetailsView.Text =
+        view._summaryView.Text = $"{commitInfo.AuthorName}, {commitInfo.Time:yyyy/MM/dd HH:mm} • {commitInfo.Summary}";
+        view._profileIcon.Source = new BitmapImage(new Uri(GetGravatarUrl(commitInfo.AuthorEmail), UriKind.Absolute));
+        view._commitDetailsView.Text =
             $"""
             {commitInfo.AuthorName} | {commitInfo.Time:f}
             {commitInfo.Summary}
             Commit: {commitInfo.Hash.Substring(7)}
             """;
-        _container.Visibility = Visibility.Visible;
 
-        return _container;
+        view._container.Visibility = Visibility.Visible;
+
+        return view._container;
     }
 
     static string GetGravatarUrl(string email)


### PR DESCRIPTION
PR title is self explanatory. View factory statics changed to a per-view class stored in dictionary so multiple adornments can exist on-screen at a time

Has conflicts with https://github.com/AmSmart/VSGitBlame/pull/9 but they're easy to resolve if merged. A couple sections of code on that branch conflict for non-use of `CommitInfoView`