### PR TITLE
Use TextTop for vertical offset to handle lines that contain an IntraTextAdornment

### DIFF
--- a/VSGitBlame/CommitInfoAdornment.cs
+++ b/VSGitBlame/CommitInfoAdornment.cs
@@ -125,7 +125,7 @@ public class CommitInfoAdornment
         var container = CommitInfoViewFactory.Get(commitInfo, _adornmentLayer);
 
         Canvas.SetLeft(container, line.Right);
-        Canvas.SetTop(container, line.Top);
+        Canvas.SetTop(container, line.TextTop);
 
         _adornmentLayer.RemoveAllAdornments();
         SnapshotSpan span = new SnapshotSpan(_adornmentLayer.TextView.TextSnapshot, Span.FromBounds(line.Start, line.End));


### PR DESCRIPTION
Brings the adornment down to the text origin instead of the line origin

Before
<img width="1146" height="72" alt="image" src="https://github.com/user-attachments/assets/76439219-1a40-4879-881b-d2a41f0fda01" />

After
<img width="1128" height="76" alt="image" src="https://github.com/user-attachments/assets/cbed303d-8e9f-4929-afe2-549ac4281d7f" />
